### PR TITLE
Profile cards navigate to memorial

### DIFF
--- a/src/components/features/profileProjectCard/profileProjectCard.css
+++ b/src/components/features/profileProjectCard/profileProjectCard.css
@@ -33,6 +33,13 @@
   border-radius: 15px;
   color: var(--grey-normal);
   width: 100%;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+}
+
+.funeral-card:hover {
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+  filter: brightness(1.05);
 }
 
 .project-info {

--- a/src/components/features/profileProjectCard/profileProjectCard.css
+++ b/src/components/features/profileProjectCard/profileProjectCard.css
@@ -35,6 +35,7 @@
   width: 100%;
   cursor: pointer;
   transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+  text-decoration: none;
 }
 
 .funeral-card:hover {

--- a/src/components/features/profileProjectCard/profileProjectCard.js
+++ b/src/components/features/profileProjectCard/profileProjectCard.js
@@ -3,13 +3,9 @@ import { calculateLifespan, formatUnit } from "../../../utils/dateHandlers.js";
 
 export function profileProjectCard(project) {
   // Create a new project card container
-  const projectCard = document.createElement("div");
+  const projectCard = document.createElement("a");
+  projectCard.href = `/project.html?id=${project.id}`;
   projectCard.classList.add("funeral-card");
-
-  // Make card clickable and redirect
-  projectCard.addEventListener("click", () => {
-    window.location.href = `/project.html?id=${project.id}`;
-  });
 
   // Add project image
   const projectImageContainer = document.createElement("div");
@@ -45,6 +41,7 @@ export function profileProjectCard(project) {
   likes.classList.add("btn-likes");
 
   likes.addEventListener("click", (e) => {
+    e.preventDefault();
     e.stopPropagation();
     // Todo: Implement like functionality?
   });

--- a/src/components/features/profileProjectCard/profileProjectCard.js
+++ b/src/components/features/profileProjectCard/profileProjectCard.js
@@ -6,6 +6,11 @@ export function profileProjectCard(project) {
   const projectCard = document.createElement("div");
   projectCard.classList.add("funeral-card");
 
+  // Make card clickable and redirect
+  projectCard.addEventListener("click", () => {
+    window.location.href = `/project.html?id=${project.id}`;
+  });
+
   // Add project image
   const projectImageContainer = document.createElement("div");
   projectImageContainer.classList.add("funeral-image");
@@ -38,6 +43,12 @@ export function profileProjectCard(project) {
   yearsCont.innerHTML = `<span class="years">Lifespan: </span><span>${formatUnit(years, "year", "years")}${formatUnit(months, "month", "months")}${formatUnit(days, "day", "days")}</span>`;
   const likes = document.createElement("button");
   likes.classList.add("btn-likes");
+
+  likes.addEventListener("click", (e) => {
+    e.stopPropagation();
+    // Todo: Implement like functionality?
+  });
+
   likes.innerHTML = `
       <img src="./src/assets/img/thumb.png" alt="Like Icon" class="like-icon" width="25px" height="25px" />
       <span>${project.upvoteCount}</span>


### PR DESCRIPTION
Issue #140 

- Profile page should now be able to redirect to specific memorial pages by clicking on the project. 
- Graveyard page already does this.

_I noticed the like button on the profile page is currently missing functionality. 
Should decide between keeping it as a button or change to just a likes-count display. Then create a small issue based on decision._