### PR TITLE
fix: use user ID in buried-by profile links to navigate to correct pr…

### DIFF
--- a/src/components/features/memorial/memorial.js
+++ b/src/components/features/memorial/memorial.js
@@ -64,7 +64,7 @@ function populateStaticFields(project) {
     label.textContent = "Buried by ";
     const link = createEl("a", {
       className: "buried-by-link",
-      href: `/profile.html?user=${encodeURIComponent(project.user.username)}`,
+      href: `/profile.html?id=${encodeURIComponent(project.user.id)}`,
     });
     link.textContent = `@${project.user.username}`;
     buriedBy.appendChild(label);


### PR DESCRIPTION
- Fixed issue where clicking buried-by link redirected to own profile
- Now correctly navigates to project creator's profile page