### PR TITLE
Style(memorial): button hover styles and mobile screen "improvments"

### DIFF
--- a/src/css/project.css
+++ b/src/css/project.css
@@ -400,9 +400,10 @@ blockquote {
   padding-top: 0.5rem;
 }
 
-.btn-icon {
+.memorial-controls .btn-icon {
   background: rgba(0, 0, 0, 0.2);
-  border: 0.0625rem solid rgba(165, 165, 165, 0.2);
+  color: var(--grey-normal);
+  border: 1px solid rgba(165, 165, 165, 0.2);
   border-radius: 0.5rem;
   padding: 4px 6px;
   min-width: 0;
@@ -415,23 +416,23 @@ blockquote {
   backdrop-filter: blur(0.25rem);
 }
 
-.btn-icon:hover {
+.memorial-controls .btn-icon:hover {
   background: rgba(0, 0, 0, 0.3);
+  color: var(--beige-normal);
+  border-color: var(--beige-normal);
 }
 
-.btn-icon svg {
-  pointer-events: none;
-  display: block;
-  transition: all 0.3s ease;
+.memorial-controls .btn-icon.btn-danger:hover {
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--color-error);
+  border-color: var(--color-error);
 }
 
 .memorial-controls .btn-icon svg {
-  transition: fill 0.3s ease;
-}
-
-.memorial-controls .btn-icon:hover svg,
-.memorial-controls .btn-icon:focus svg {
-  fill: #959595 !important;
+  pointer-events: none;
+  display: block;
+  fill: currentColor;
+  transition: all 0.3s ease;
 }
 
 .memorial-error {
@@ -464,7 +465,6 @@ button:focus-visible {
   outline-offset: 0.125rem;
 }
 
-
 @media (max-width: 1300px) {
   .tombstone-top::after,
   .tombstone-top::before {
@@ -476,7 +476,6 @@ button:focus-visible {
   :root {
     --full-multiplier: 2px;
   }
-
   .likes.upvote-btn,
   .comments.comment-btn {
     padding: 0.5rem 0.75rem;
@@ -492,24 +491,30 @@ button:focus-visible {
   .tombstone-top::before {
     bottom: calc(53 * var(--full-multiplier));
   }
-
   .tombstone-title {
     font-size: 2.5rem;
   }
-
   .tombstone-base {
     flex-direction: column;
-    gap: 1rem;
+    gap: 2.6rem;
     padding: 2rem 1rem;
+    padding-bottom: 3rem;
   }
-
   .tombstone-interactions {
-    justify-content: center;
+    gap: 0.3rem;
   }
-
   .page-subtitle {
     top: 10rem;
     font-size: 1.2rem;
+  }
+  .tombstone-type {
+    font-size: 0.6rem;
+    padding: 0.35em 0.85em;
+  }
+  .tombstone-cause {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
   }
 }
 
@@ -517,7 +522,6 @@ button:focus-visible {
   :root {
     --full-multiplier: 1.2px;
   }
-
   .tombstone-title {
     font-size: 2rem;
   }
@@ -533,12 +537,27 @@ button:focus-visible {
   .tombstone-title {
     font-size: 1.8rem;
   }
-
   .tombstone-body {
     padding: 3rem 3rem 8rem;
   }
-
   .page-subtitle {
     font-size: 1rem;
+  }
+  .tombstone-lifespan-block {
+    padding: 0.5rem 0.75rem;
+  }
+  .tombstone-cause,
+  .tombstone-lifespan {
+    gap: 0.5em;
+    font-size: 0.85rem;
+  }
+  .tombstone-description {
+    font-size: 0.9rem;
+  }
+  .tombstone-base {
+    gap: 3.8rem;
+  }
+  .tombstone-types {
+    gap: 0.35rem;
   }
 }


### PR DESCRIPTION

- Changed hover style on edit and delete buttons to match comment section buttons.
- Minor changes to mobile layout with smaller font sizes and keeping types/tags inside the tombstone base.
- **Note**: Delete button hover style depends on #175 