### PR TITLE
Refactor: graveyard

### DIFF
--- a/src/components/features/graveyard/fetchAndRenderProjects.js
+++ b/src/components/features/graveyard/fetchAndRenderProjects.js
@@ -1,0 +1,65 @@
+import { getPageState } from "./getPageState.js";
+import { setPageState } from "./setPageState.js";
+import {
+  projectCard,
+  projectCardSkeleton,
+} from "../projectCard/projectCard.js";
+import { showSkeletons } from "./showSkeletons.js";
+import { pagination } from "../pagination/pagination.js";
+import { api } from "../../../main.js";
+
+/**
+ * Fetch projects from the API and render them into the graveyard page.
+ *
+ * - Reads pagination + filter state from the current URL.
+ * - Shows skeleton placeholders while loading.
+ * - Requests the project list from the API with the correct query params.
+ * - Renders project cards or a “no projects” message.
+ * - Sets up pagination controls and wires them to update the URL and re-render.
+ *
+ * @async
+ * @function fetchAndRenderProjects
+ * @returns {Promise<void>} Resolves after the DOM is updated.
+ *
+ * @example
+ * await fetchAndRenderProjects();
+ */
+export async function fetchAndRenderProjects() {
+  const projectsContainer = document.querySelector(".project-container");
+  const paginationContainer = document.querySelector(".pagination");
+  const { order, orderBy, query, types, limit, offset, currentPage } =
+    getPageState();
+  showSkeletons(limit, projectsContainer, projectCardSkeleton);
+  try {
+    const options = { offset, limit, types, order, orderBy };
+    if (query?.length) options.query = query;
+    const res = await api.getAllProjects(options);
+
+    const projects = res.data || [];
+    const total = res.meta?.total || 0;
+    const totalPages = Math.ceil(total / limit);
+
+    projectsContainer.innerHTML = "";
+
+    if (projects.length === 0) {
+      projectsContainer.innerHTML =
+        "<p>No projects found. Try another page.</p>";
+    } else {
+      projects.forEach((project) => {
+        projectsContainer.append(projectCard(project));
+      });
+    }
+
+    pagination({
+      current: currentPage,
+      total: totalPages,
+      container: paginationContainer,
+      onPageChange: (newPage) => {
+        setPageState({ offset: (newPage - 1) * limit }, fetchAndRenderProjects);
+      },
+    });
+  } catch {
+    projectsContainer.innerHTML =
+      "<p>An error occurred fetching projects, please refresh the page.</p>";
+  }
+}

--- a/src/components/features/graveyard/getPageState.js
+++ b/src/components/features/graveyard/getPageState.js
@@ -1,0 +1,34 @@
+/**
+ * Parse the current URL query string and return pagination + filter state.
+ *
+ * Ensures `limit` stays within 1–100, derives `offset` and `currentPage`,
+ * and provides safe defaults if params are missing.
+ *
+ * @returns {Object} Page state object
+ * @returns {"asc"|"desc"} return.order   Sort direction (default: "desc")
+ * @returns {string}       return.orderBy Field to order by (default: "createdAt")
+ * @returns {string}       return.query   Free-text search query (default: "")
+ * @returns {string}       return.types   Comma-separated type IDs (default: "")
+ * @returns {number}       return.limit   Page size, clamped between 1 and 100
+ * @returns {number}       return.offset  Result offset, derived from `offset` param
+ * @returns {number}       return.currentPage 1-based page number, derived from offset/limit
+ */
+export function getPageState() {
+  const params = new URLSearchParams(window.location.search);
+
+  let limit = Number(params.get("limit")) || 10;
+  limit = Math.min(100, Math.max(1, limit));
+
+  const offset = Number(params.get("offset")) || 0;
+  const currentPage = Math.floor(offset / limit) + 1;
+
+  return {
+    order: params.get("order") || "desc",
+    orderBy: params.get("orderBy") || "createdAt",
+    query: params.get("query") || "",
+    types: params.get("types") || "",
+    limit,
+    offset,
+    currentPage,
+  };
+}

--- a/src/components/features/graveyard/index.js
+++ b/src/components/features/graveyard/index.js
@@ -1,0 +1,5 @@
+export * from "./getPageState.js";
+export * from "./showSkeletons.js";
+export * from "./setPageState.js";
+export * from "./setupGraveyardForms.js";
+export * from "./fetchAndRenderProjects.js";

--- a/src/components/features/graveyard/setPageState.js
+++ b/src/components/features/graveyard/setPageState.js
@@ -1,0 +1,27 @@
+/**
+ * Update the current page URL query parameters and optionally run a callback.
+ *
+ * - Merges the provided `updates` into the current URL search params.
+ * - Any key with `undefined`, `null`, or `""` as its value is removed.
+ * - Uses `history.pushState` to create a new history entry with the updated URL.
+ * - Invokes the optional callback after the URL is updated.
+ *
+ * @param {Record<string, string|number|null|undefined>} updates
+ *   Key/value pairs to set in the URL query string.
+ *   Values are coerced to strings; falsy values (`undefined`, `null`, `""`)
+ *   will remove the key.
+ * @param {Function} [fn=() => {}]
+ *   Optional callback function to run after the URL is updated.
+ */
+export function setPageState(updates, fn = () => {}) {
+  const url = new URL(window.location);
+  Object.entries(updates).forEach(([key, value]) => {
+    if (value === undefined || value === "" || value === null) {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, value);
+    }
+  });
+  window.history.pushState({}, "", url);
+  fn();
+}

--- a/src/components/features/graveyard/setupGraveyardForms.js
+++ b/src/components/features/graveyard/setupGraveyardForms.js
@@ -1,0 +1,58 @@
+import { api } from "../../../main.js";
+import { getPageState } from "./getPageState.js";
+
+/**
+ * Initialise the filter and search form controls on the graveyard page.
+ *
+ * - Reads current page state from the URL (order, orderBy, limit, query, types).
+ * - Populates the form inputs with those values.
+ * - Fetches the list of available types from the API and builds checkboxes for them.
+ * - Marks any checkboxes as checked if they match the current state.
+ *
+ * @async
+ * @function setupGraveyardForms
+ * @returns {Promise<void>} Resolves when the form elements are populated.
+ *
+ * @example
+ * import { setupGraveyardForms } from "../components/features/graveyard/index.js";
+ * setupGraveyardForms();
+ */
+export async function setupGraveyardForms() {
+  let { order, orderBy, types, limit, query } = getPageState();
+  const orderSelector = document.querySelector("#order-selector");
+  orderSelector.value = order;
+  const orderBySelector = document.querySelector("#orderby-selector");
+  orderBySelector.value = orderBy;
+  const limitSelector = document.querySelector("#limit-selector");
+  limitSelector.value = limit;
+  const typesCheckboxes = document.querySelector("#types");
+  const searchForm = document.getElementById("search-form");
+  searchForm.query.value = query;
+
+  const typesRes = await api.getAllTypes();
+  let typesArray = [];
+  if (typesRes.success) {
+    typesArray = typesRes.data;
+  }
+
+  typesArray.forEach((type) => {
+    const label = document.createElement("label");
+    label.setAttribute("for", `type-${type.id}`);
+    label.style.display = "block"; // if you want each on a new line
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.name = "types";
+    checkbox.value = type.id;
+    checkbox.id = `type-${type.id}`;
+
+    const selectTypes = types.split(",");
+    if (selectTypes.includes(`${type.id}`)) {
+      checkbox.checked = true;
+    }
+
+    label.appendChild(checkbox);
+    label.append(` ${type.name}`);
+    typesCheckboxes.appendChild(label);
+  });
+}

--- a/src/components/features/graveyard/showSkeletons.js
+++ b/src/components/features/graveyard/showSkeletons.js
@@ -1,0 +1,17 @@
+/**
+ * Render a set of skeleton placeholders into a container.
+ *
+ * Clears the container’s existing contents and appends the given
+ * number of skeleton elements by calling the provided render function.
+ *
+ * @param {number} count - How many skeletons to render.
+ * @param {HTMLElement} container - DOM element where skeletons will be injected.
+ * @param {() => string} renderFn - Function returning the HTML string for a skeleton.
+ *   If you want to return a DOM element instead, change this signature to `() => HTMLElement`.
+ */
+export function showSkeletons(count, container, renderFn) {
+  container.innerHTML = "";
+  for (let i = 0; i < count; i++) {
+    container.innerHTML += renderFn();
+  }
+}

--- a/src/pages/graveyard.js
+++ b/src/pages/graveyard.js
@@ -5,20 +5,27 @@ import {
 import { pagination } from "../components/features/pagination/pagination.js";
 import { api } from "../main.js";
 
-const urlParams = new URLSearchParams(window.location.search);
-let order = urlParams.get("order") || "desc";
-let orderBy = urlParams.get("orderBy") || "createdAt";
-let query = urlParams.get("query") || "";
-let types = urlParams.get("types") || "";
-let limit = parseInt(urlParams.get("limit"), 10) || 10;
-if (limit > 100) {
-  limit = 100;
+function getPageState() {
+  const params = new URLSearchParams(window.location.search);
+
+  let limit = Number(params.get("limit")) || 10;
+  limit = Math.min(100, Math.max(1, limit));
+
+  const offset = Number(params.get("offset")) || 0;
+  const currentPage = Math.floor(offset / limit) + 1;
+
+  return {
+    order: params.get("order") || "desc",
+    orderBy: params.get("orderBy") || "createdAt",
+    query: params.get("query") || "",
+    types: params.get("types") || "",
+    limit,
+    offset,
+    currentPage,
+  };
 }
-let currentPage =
-  Math.floor(
-    (parseInt(urlParams.get("offset"), 10) || 0) /
-      (parseInt(urlParams.get("limit"), 10) || 10),
-  ) + 1;
+let { order, orderBy, query, types, limit, offset, currentPage } =
+  getPageState();
 
 const projectsContainer = document.querySelector(".project-container");
 const paginationContainer = document.querySelector(".pagination");
@@ -33,7 +40,7 @@ function showSkeletons(count = limit) {
 async function fetchAndRenderProjects(page = 1) {
   showSkeletons();
   try {
-    const offset = (page - 1) * limit;
+    offset = (page - 1) * limit;
     const url = new URL(window.location);
     url.searchParams.set("offset", offset);
     window.history.pushState({}, "", url);
@@ -180,4 +187,10 @@ clearSearchBtn.addEventListener("click", async (e) => {
   query = "";
   formHandler(e);
   console.log(query);
+});
+
+addEventListener("popstate", () => {
+  [order, orderBy, query, types, limit, offset, currentPage] =
+    Object.values(getPageState());
+  fetchAndRenderProjects(currentPage);
 });

--- a/src/pages/graveyard.js
+++ b/src/pages/graveyard.js
@@ -1,91 +1,13 @@
 import {
-  projectCard,
-  projectCardSkeleton,
-} from "../components/features/projectCard/projectCard.js";
-import { pagination } from "../components/features/pagination/pagination.js";
-import { api } from "../main.js";
+  setPageState,
+  setupGraveyardForms,
+  fetchAndRenderProjects,
+} from "../components/features/graveyard/index.js";
 
-function getPageState() {
-  const params = new URLSearchParams(window.location.search);
-
-  let limit = Number(params.get("limit")) || 10;
-  limit = Math.min(100, Math.max(1, limit));
-
-  const offset = Number(params.get("offset")) || 0;
-  const currentPage = Math.floor(offset / limit) + 1;
-
-  return {
-    order: params.get("order") || "desc",
-    orderBy: params.get("orderBy") || "createdAt",
-    query: params.get("query") || "",
-    types: params.get("types") || "",
-    limit,
-    offset,
-    currentPage,
-  };
-}
-let { order, orderBy, query, types, limit, offset, currentPage } =
-  getPageState();
-
-const projectsContainer = document.querySelector(".project-container");
-const paginationContainer = document.querySelector(".pagination");
-
-function showSkeletons(count = limit) {
-  projectsContainer.innerHTML = "";
-  for (let i = 0; i < count; i++) {
-    projectsContainer.innerHTML += projectCardSkeleton();
-  }
-}
-
-async function fetchAndRenderProjects(page = 1) {
-  showSkeletons();
-  try {
-    offset = (page - 1) * limit;
-    const url = new URL(window.location);
-    url.searchParams.set("offset", offset);
-    window.history.pushState({}, "", url);
-    let options = { offset, limit, types, order, orderBy };
-    query?.length ? (options.query = query) : delete options.query;
-    const res = await api.getAllProjects(options);
-
-    console.log(res);
-
-    const projects = res.data || [];
-    const total = res.meta?.total || 0;
-    const totalPages = Math.ceil(total / limit);
-
-    projectsContainer.innerHTML = "";
-
-    if (projects.length === 0) {
-      projectsContainer.innerHTML =
-        "<p>No projects found. Try another page.</p>";
-    } else {
-      projects.forEach((project) => {
-        projectsContainer.append(projectCard(project));
-      });
-    }
-
-    pagination({
-      current: currentPage,
-      total: totalPages,
-      container: paginationContainer,
-      onPageChange: (newPage) => {
-        currentPage = newPage;
-        fetchAndRenderProjects(newPage);
-      },
-    });
-  } catch (err) {
-    console.log(err);
-    projectsContainer.innerHTML =
-      "<p>An error occurred fetching projects, please refresh the page.</p>";
-  }
-}
-
-fetchAndRenderProjects(currentPage);
+fetchAndRenderProjects();
 
 /* Modal for filter */
 const dialog = document.querySelector("dialog");
-const typesCheckboxes = document.querySelector("#types");
 const dialogCloseBtn = document.querySelector("#close-dialog");
 const dialogOpenBtn = document.querySelector("#open-dialog");
 dialogOpenBtn.addEventListener("click", () => {
@@ -97,74 +19,24 @@ dialogCloseBtn.addEventListener("click", () => {
 });
 
 /* Form Setup */
-const orderSelector = document.querySelector("#order-selector");
-orderSelector.value = order;
-const orderBySelector = document.querySelector("#orderby-selector");
-orderBySelector.value = orderBy;
-const limitSelector = document.querySelector("#limit-selector");
-limitSelector.value = limit;
 
-const typesRes = await api.getAllTypes();
-let typesArray = [];
-if (typesRes.success) {
-  typesArray = typesRes.data;
-}
-
-typesArray.forEach((type) => {
-  const label = document.createElement("label");
-  label.setAttribute("for", `type-${type.id}`);
-  label.style.display = "block"; // if you want each on a new line
-
-  const checkbox = document.createElement("input");
-  checkbox.type = "checkbox";
-  checkbox.name = "types";
-  checkbox.value = type.id;
-  checkbox.id = `type-${type.id}`;
-
-  const selectTypes = types.split(",");
-  if (selectTypes.includes(`${type.id}`)) {
-    checkbox.checked = true;
-  }
-
-  label.appendChild(checkbox);
-  label.append(` ${type.name}`);
-  typesCheckboxes.appendChild(label);
-});
+setupGraveyardForms();
 
 /* Form Handler */
 const filterForm = document.getElementById("project-filters");
 const searchForm = document.getElementById("search-form");
-searchForm.query.value = query;
 async function formHandler(e) {
   e.preventDefault();
   const formData = new FormData(filterForm);
-  let searchQuery = searchForm.query.value;
   const data = Object.fromEntries(formData.entries());
+  data.types = formData.getAll("types").join(",");
+  const searchQuery = searchForm.query.value.trim();
+  if (searchQuery) data.query = searchQuery;
 
-  const selectedTypes = formData.getAll("types").join(",");
-  data.types = selectedTypes;
-  if (searchQuery.trim().length > 0) {
-    data.query = searchQuery;
-  } else {
-    delete data.query;
-  }
-  console.log(data.query);
-  const url = new URL(window.location);
-  url.searchParams.forEach((_, key) => url.searchParams.delete(key));
-  for (const [key, value] of Object.entries(data)) {
-    url.searchParams.set(key, value);
-  }
-
-  window.history.pushState({}, "", url);
-  order = data.order;
-  orderBy = data.orderBy;
-  query = data.query;
-  types = selectedTypes;
-  limit = data.limit;
-  currentPage = 1;
-
-  fetchAndRenderProjects(currentPage);
-  dialog.close();
+  setPageState(data, () => {
+    fetchAndRenderProjects();
+    dialog.close();
+  });
 }
 
 filterForm.addEventListener("submit", async (e) => {
@@ -184,13 +56,9 @@ clearFilterBtn.addEventListener("click", async (e) => {
 const clearSearchBtn = document.querySelector("#clear-search");
 clearSearchBtn.addEventListener("click", async (e) => {
   searchForm.reset();
-  query = "";
   formHandler(e);
-  console.log(query);
 });
 
 addEventListener("popstate", () => {
-  [order, orderBy, query, types, limit, offset, currentPage] =
-    Object.values(getPageState());
-  fetchAndRenderProjects(currentPage);
+  fetchAndRenderProjects();
 });


### PR DESCRIPTION
Refactored the Graveyard results page into modular, reusable utilities:
- Extracted page state handling into getPageState and setPageState helpers.
- Added showSkeletons utility for rendering loading placeholders.
- Added setupGraveyardForms to initialize filter/search form state and type checkboxes.
- Moved project fetch/render logic into fetchAndRenderProjects.
- Centralized exports in graveyard/index.js for cleaner imports.
- Updated graveyard.js page to consume these utilities, simplifying page logic.

This should help with maintainability by removing duplicate logic, consolidating URL state handling and making the URL the single source of truth for the page.