### PR TITLE
fixed overflow on articles in explore section

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -357,6 +357,14 @@ h2 {
   border-radius: var(--section-border-radius);
 }
 
+@media (max-width: 450px) {
+  .explore-container article {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
 @media (max-width: 900px) {
   .bury-project-container {
     display: block;


### PR DESCRIPTION
This pull request introduces a responsive design improvement for small screens. The main change ensures that articles within the `.explore-container` are displayed in a column layout and centered when viewed on devices with a screen width of 450px or less.

Responsive design update:

* Added a media query to `index.css` to display `.explore-container article` elements as flex columns with centered text on screens 450px wide or smaller.